### PR TITLE
pip instead of setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 PYTHON = python3
 
 install:
-	sudo $(PYTHON) setup.py install
+#	sudo $(PYTHON) setup.py install
+	sudo pip install .
 
-uninstall: clean
-	sudo rm -rf /usr/local/bin/pygmentize
-	sudo rm -rf /usr/local/lib/python2.7/dist-packages/ssrmint-0.1-py2.7.egg
+#uninstall: clean
+#	sudo rm -rf /usr/local/bin/pygmentize
+#	sudo rm -rf /usr/local/lib/python2.7/dist-packages/ssrmint-0.1-py2.7.egg
 
 clean:
 	sudo rm -rf ./build


### PR DESCRIPTION
If one uses 

`sudo python setup.py install`

for installation, this results in files being written in

`/usr/local/lib/pythonX.YZ/dist-packages`

and warnings, e.g.:

```
/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/command/easy_install.py:158: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 1.1build1 is an invalid version and will not be supported in a future release
  warnings.warn(
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 0.1.43ubuntu1 is an invalid version and will not be supported in a future release
  warnings.warn(
```

Replacing with

`sudo pip install .`

seems to work equally as well and does not generate warnings (besides the one about being a superuser).

Do you think this is the right fix @xuanruiqi ?
